### PR TITLE
No jquery

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,16 +1,27 @@
-import JSONAPIAdapter from 'ember-data/adapters/json-api';
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+import AdapterFetchMixin from 'ember-fetch/mixins/adapter-fetch';
 import config from 'mir/config/environment';
 
-export default JSONAPIAdapter.extend(DataAdapterMixin, {
+export default JSONAPIAdapter.extend(AdapterFetchMixin, {
+  session: service(),
+
   /* Ember */
   host: config.DS.host,
   namespace: config.DS.namespace,
 
-  /* DataAdapterMixin */
-  authorize(xhr) {
-    let { access_token } = get(this, 'session.data.authenticated');
-    xhr.setRequestHeader('Authorization', `Bearer ${access_token}`);
+  authorizer: 'authorizer:oauth2',
+
+  /* mir */
+  ajaxOptions() {
+    const authorizer = get(this, 'authorizer');
+    const options = this._super(...arguments) || {};
+    options.headers = options.headers || {};
+    options.headers['Content-Type'] = 'application/vnd.api+json';
+    get(this, 'session').authorize(authorizer, (headerName, headerValue) => {
+      options.headers[headerName] = headerValue;
+    });
+    return options;
   }
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,7 +1,7 @@
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import AdapterFetchMixin from 'ember-fetch/mixins/adapter-fetch';
 import config from 'mir/config/environment';
-import { computed, get } from '@ember/object';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default JSONAPIAdapter.extend(AdapterFetchMixin, {
@@ -11,22 +11,6 @@ export default JSONAPIAdapter.extend(AdapterFetchMixin, {
   host: config.DS.host,
   namespace: config.DS.namespace,
 
-  /*
-  authorizer: 'authorizer:oauth2-bearer',
-  */
-
-  /* mir */
-  zzajaxOptions() {
-    const authorizer = get(this, 'authorizer');
-    const options = this._super(...arguments) || {};
-    options.headers = options.headers || {};
-    options.headers['Content-Type'] = 'application/vnd.api+json';
-    get(this, 'session').authorize(authorizer, (headerName, headerValue) => {
-      options.headers[headerName] = headerValue;
-    });
-    return options;
-  },
-
   headers: computed('session.data.authenticated.token', function() {
     const headers = {};
     headers['Content-Type'] = 'application/vnd.api+json';
@@ -34,7 +18,6 @@ export default JSONAPIAdapter.extend(AdapterFetchMixin, {
       const token = this.session.data.authenticated['access_token'];
       headers['Authorization'] = `Bearer ${token}`;
     }
-
     return headers;
   })
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,7 +1,7 @@
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import AdapterFetchMixin from 'ember-fetch/mixins/adapter-fetch';
 import config from 'mir/config/environment';
-import { get } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default JSONAPIAdapter.extend(AdapterFetchMixin, {
@@ -11,10 +11,12 @@ export default JSONAPIAdapter.extend(AdapterFetchMixin, {
   host: config.DS.host,
   namespace: config.DS.namespace,
 
-  authorizer: 'authorizer:oauth2',
+  /*
+  authorizer: 'authorizer:oauth2-bearer',
+  */
 
   /* mir */
-  ajaxOptions() {
+  zzajaxOptions() {
     const authorizer = get(this, 'authorizer');
     const options = this._super(...arguments) || {};
     options.headers = options.headers || {};
@@ -23,5 +25,16 @@ export default JSONAPIAdapter.extend(AdapterFetchMixin, {
       options.headers[headerName] = headerValue;
     });
     return options;
-  }
+  },
+
+  headers: computed('session.data.authenticated.token', function() {
+    const headers = {};
+    headers['Content-Type'] = 'application/vnd.api+json';
+    if (this.session.isAuthenticated) {
+      const token = this.session.data.authenticated['access_token'];
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return headers;
+  })
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,8 +1,8 @@
-import { get } from '@ember/object';
-import { inject as service } from '@ember/service';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import AdapterFetchMixin from 'ember-fetch/mixins/adapter-fetch';
 import config from 'mir/config/environment';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default JSONAPIAdapter.extend(AdapterFetchMixin, {
   session: service(),

--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,3 +1,3 @@
 {
-  "jquery-integration": true
+  "jquery-integration": false
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,6 @@ const VERSION = GETENVJSON().version;
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
     fingerprint: {
       extensions: ['css', 'gif', 'js', 'jpg', 'png', 'map', 'svg']
     },
@@ -30,6 +29,10 @@ module.exports = function(defaults) {
 
     svgJar: {
       sourceDirs: ['public/images']
+    },
+
+    vendorFiles: {
+      'jquery.js': null // removes jQuery from build
     }
   });
 

--- a/fastboot/initializers/ajax.js
+++ b/fastboot/initializers/ajax.js
@@ -1,0 +1,9 @@
+export default {
+  name: 'ajax-service',
+  initialize() {
+    /* noop
+     * This is to override Fastboot's initializer which prevents ember-fetch from working
+     * https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/fastboot/initializers/ajax.js
+     */
+  }
+};

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -117,5 +117,7 @@ export default function() {
   this.del('/medias/:id', (schema, request) => {
     let media = schema.medias.find(request.params.id);
     media.destroy();
+    // TODO: Hacks
+    return { data: null }; // i shouldn't have to return anything here
   });
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -117,7 +117,5 @@ export default function() {
   this.del('/medias/:id', (schema, request) => {
     let media = schema.medias.find(request.params.id);
     media.destroy();
-    // TODO: Hacks
-    return { data: null }; // i shouldn't have to return anything here
   });
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-source": "~3.4.4",
     "ember-svg-jar": "^1.2.2",
     "ember-test-component": "^0.2.1",
-    "ember-youtube": "^0.9.4",
+    "ember-youtube": "^0.9.5",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",
     "eslint-plugin-ember": "^5.4.0",
@@ -80,9 +80,6 @@
     "sass": "^1.18.0",
     "system-font-i18n-css": "^1.1.0",
     "torii": "^0.10.1"
-  },
-  "resolutions": {
-    "ember-youtube": "github:mirai-audio/ember-youtube#remove-jquery"
   },
   "engines": {
     "node": ">= 10.*"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test": "COVERAGE=true ember test"
   },
   "devDependencies": {
-    "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
     "bulma": "^0.7.4",
@@ -81,6 +80,9 @@
     "sass": "^1.18.0",
     "system-font-i18n-css": "^1.1.0",
     "torii": "^0.10.1"
+  },
+  "resolutions": {
+    "ember-youtube": "github:mirai-audio/ember-youtube#remove-jquery"
   },
   "engines": {
     "node": ">= 10.*"

--- a/tests/integration/components/ma-media-detail-test.js
+++ b/tests/integration/components/ma-media-detail-test.js
@@ -42,6 +42,6 @@ module('Integration | Component | ma-media-detail', function(hooks) {
       assert.dom('iframe').exists();
       assert.dom('iframe').hasAttribute('src');
       done();
-    }, 500);
+    }, 1000);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5918,9 +5918,10 @@ ember-validators@^2.0.0:
     ember-cli-babel "^6.9.2"
     ember-require-module "^0.3.0"
 
-ember-youtube@^0.9.4, "ember-youtube@github:mirai-audio/ember-youtube#remove-jquery":
-  version "0.9.4"
-  resolved "https://codeload.github.com/mirai-audio/ember-youtube/tar.gz/083a355ccce8d410b657c60ae71b3f8326a52629"
+ember-youtube@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/ember-youtube/-/ember-youtube-0.9.5.tgz#bb9b77a988672ad47d48f612e27e372fe3a223cb"
+  integrity sha512-4tCGe2Jk2MAgCVKrkplfe58G/PziwaY+NbGJsYFQVIWb36Uj+SRbfnzmVsapAXLX2sq+3jfFWC3RDcXP9WMuTQ==
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,18 +719,6 @@
   dependencies:
     "@ember-intl/intl-messageformat" "^2.0.0"
 
-"@ember/jquery@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-0.6.0.tgz#5fe9d39b15c9d47fe495302b2a6176059a6267cd"
-  integrity sha512-O81+JslKE7bsV+5wrhXEmBU1Bpte2u9bm6MLIoRYePvWDo50l7llDW1RM38l1KkeSj/s7iXTsviZ4uunhIcKow==
-  dependencies:
-    broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^3.0.2"
-    ember-cli-babel "^7.4.0"
-    ember-cli-version-checker "^3.0.0"
-    jquery "^3.3.1"
-    resolve "^1.10.0"
-
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -5066,30 +5054,6 @@ ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.4.3, ember-cl
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.4.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.6.0.tgz#2e7f1df888fb62eb54d170defce4b6c536e8dfd3"
-  integrity sha512-2m400ZW9c4EE343g/j1U7beJgjJezTdDCgXM2koHdhpLlZB1Kz7iQw8S+t8gzXGwSGXlf7C7v0RHxP1/bo8frA==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-transform-modules-amd" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.2.0"
-    "@babel/polyfill" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/runtime" "^7.2.0"
-    amd-name-resolver "^1.2.1"
-    babel-plugin-debug-macros "^0.3.0"
-    babel-plugin-ember-modules-api-polyfill "^2.8.0"
-    babel-plugin-module-resolver "^3.1.1"
-    broccoli-babel-transpiler "^7.1.2"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.1"
-    broccoli-source "^1.1.0"
-    clone "^2.1.2"
-    ember-cli-version-checker "^2.1.2"
-    ensure-posix-path "^1.0.2"
-    semver "^5.5.0"
-
 ember-cli-broccoli-sane-watcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-3.0.0.tgz#dc1812c047e1ceec4413d3c41b51a9ffc61b4cfe"
@@ -5954,10 +5918,9 @@ ember-validators@^2.0.0:
     ember-cli-babel "^6.9.2"
     ember-require-module "^0.3.0"
 
-ember-youtube@^0.9.4:
+ember-youtube@^0.9.4, "ember-youtube@github:mirai-audio/ember-youtube#remove-jquery":
   version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ember-youtube/-/ember-youtube-0.9.4.tgz#7a5421b35bdbd19b2c3f4f1279531fd669720078"
-  integrity sha512-Jvf99uM/N3wGGGgHO7f4Aptn6hLGlehbbXoIw+1MNfLGK+SxyxRwuQPwceOG/LNW1Lo2h4imdViImoRLDRy4zw==
+  resolved "https://codeload.github.com/mirai-audio/ember-youtube/tar.gz/083a355ccce8d410b657c60ae71b3f8326a52629"
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"


### PR DESCRIPTION
# Remove jQuery as a dependency

Resolves issue #31 

### status: On Hold

1. ~On hold, requires changes to ` app/adapters/application.js` that seem cludgy~ Why do we need to add the `ajaxOptions` hook if the DataProviderMixin already provides it?
1. ~On hold, fastboot is throwing an exception on `catch` because `ember-fetch` isn't yet compatable with fastboot~

### Quality

* [x] Submitted a ticket for my issue if one did not already exist
* [x] Ticket number is in the subject of the commit message
* [x] Used [Github auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or PR
* [x] Updated documentation for changes to the API
* [x] Added new tests for new functionality, and tests are passing
* [x] Code, writing, and design changes follow the [Style guides](https://github.com/mirai-audio/mir/wiki/Style-Guides)
* [x] Single commit - `git rebase -i` off `master`
* [x] No dangling orphan code

_If there’s a checkbox you can’t complete for any reason, that's okay, just
explain in detail why you weren’t able to do so._
